### PR TITLE
fix: remove duplicate labels in invoice upload form

### DIFF
--- a/src/components/invoices/UploadInvoiceForm.tsx
+++ b/src/components/invoices/UploadInvoiceForm.tsx
@@ -227,7 +227,6 @@ export default function UploadInvoiceForm({ onSuccess }: UploadInvoiceFormProps)
       <FormField label="Date de la facture" error={dateError} required>
         <Input
           type="datetime-local"
-          label="Date de la facture"
           value={date}
           onChange={(e) => setDate(e.target.value)}
           required
@@ -238,7 +237,6 @@ export default function UploadInvoiceForm({ onSuccess }: UploadInvoiceFormProps)
       <FormField label="Fournisseur">
         <Input
           type="text"
-          label="Fournisseur"
           value={supplier}
           onChange={(e) => setSupplier(e.target.value)}
           disabled={loading}


### PR DESCRIPTION
## Summary
- remove redundant `label` props from date and supplier inputs in UploadInvoiceForm

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a997beb79c8321b52596de51e24cc0