### PR TITLE
chore: enforce three-letter invoice currency

### DIFF
--- a/supabase/migrations/20250823120000_stable_currency.sql
+++ b/supabase/migrations/20250823120000_stable_currency.sql
@@ -1,0 +1,29 @@
+/*
+  # Enforce currency format for invoice
+
+  - Normalize existing currency values to three-letter uppercase codes.
+  - Change column type to char(3).
+  - Add CHECK constraint to ensure three uppercase letters.
+*/
+
+-- Normalize existing currency values
+UPDATE public.invoice
+SET currency = upper(substr(currency, 1, 3));
+
+-- Change column type to char(3)
+ALTER TABLE public.invoice
+ALTER COLUMN currency TYPE char(3)
+USING currency;
+
+-- Add CHECK constraint for three uppercase letters
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.check_constraints
+    WHERE constraint_name = 'invoice_currency_format_check'
+  ) THEN
+    ALTER TABLE public.invoice
+    ADD CONSTRAINT invoice_currency_format_check
+    CHECK (currency ~ '^[A-Z]{3}$');
+  END IF;
+END $$;

--- a/supabase/tests/test_invoice_currency.sql
+++ b/supabase/tests/test_invoice_currency.sql
@@ -1,0 +1,29 @@
+-- Test invoice currency constraint
+
+-- Ensure the constraint exists
+SELECT conname FROM pg_constraint
+WHERE conname = 'invoice_currency_format_check';
+
+-- Attempt to insert an invalid currency value
+DO $$
+DECLARE
+  org_id uuid;
+  rest_id uuid;
+BEGIN
+  SELECT o.id, r.id INTO org_id, rest_id
+  FROM organization o
+  JOIN restaurant r ON r.organization_id = o.id
+  LIMIT 1;
+
+  IF org_id IS NULL THEN
+    RAISE NOTICE 'No organization/restaurant data available to test insert';
+  ELSE
+    BEGIN
+      INSERT INTO public.invoice (id, organization_id, restaurant_id, file_url, invoice_date, currency)
+      VALUES (gen_random_uuid(), org_id, rest_id, 'http://example.com', now(), 'usd');
+      RAISE EXCEPTION 'Constraint invoice_currency_format_check not enforced';
+    EXCEPTION WHEN check_violation THEN
+      RAISE NOTICE 'Constraint enforced as expected';
+    END;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- restrict invoice.currency to three uppercase characters with a check constraint
- add SQL test verifying the currency constraint

## Testing
- `psql -f supabase/tests/test_invoice_currency.sql` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b551ab30832189b8d209f03961f9