### PR TITLE
chore: enforce not null on invoice created_at

### DIFF
--- a/supabase/migrations/20250823102000_sturdy_field.sql
+++ b/supabase/migrations/20250823102000_sturdy_field.sql
@@ -1,0 +1,16 @@
+/*
+  # Enforce NOT NULL on invoice.created_at
+
+  1. Update existing NULL values
+  2. Add NOT NULL constraint
+*/
+
+-- Replace NULL created_at with current timestamp
+UPDATE public.invoice
+SET created_at = NOW()
+WHERE created_at IS NULL;
+
+-- Make created_at NOT NULL
+ALTER TABLE public.invoice
+ALTER COLUMN created_at SET NOT NULL;
+


### PR DESCRIPTION
## Summary
- ensure invoice.created_at has no NULL values and enforce NOT NULL constraint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b568cbf08321b26cc7cde8fe3b68