### PR TITLE
fix: use auth.uid() in migrations

### DIFF
--- a/supabase/migrations/20250823091233_autumn_grove.sql
+++ b/supabase/migrations/20250823091233_autumn_grove.sql
@@ -52,12 +52,12 @@ CREATE POLICY "Users can manage suppliers in their organization"
   USING (organization_id IN (
     SELECT profiles.organization_id
     FROM profiles
-    WHERE profiles.user_id = uid()
+    WHERE profiles.user_id = auth.uid()
   ))
   WITH CHECK (organization_id IN (
     SELECT profiles.organization_id
     FROM profiles
-    WHERE profiles.user_id = uid()
+    WHERE profiles.user_id = auth.uid()
   ));
 
 CREATE POLICY "Users can read suppliers in their organization"
@@ -67,7 +67,7 @@ CREATE POLICY "Users can read suppliers in their organization"
   USING (organization_id IN (
     SELECT profiles.organization_id
     FROM profiles
-    WHERE profiles.user_id = uid()
+    WHERE profiles.user_id = auth.uid()
   ));
 
 -- Modify invoice table: remove supplier text column if it exists

--- a/supabase/migrations/20250823125133_damp_desert.sql
+++ b/supabase/migrations/20250823125133_damp_desert.sql
@@ -62,7 +62,7 @@ CREATE POLICY "Users can read invoice lines of their organization"
       WHERE i.organization_id IN (
         SELECT profiles.organization_id
         FROM profiles
-        WHERE profiles.user_id = uid()
+        WHERE profiles.user_id = auth.uid()
       )
     )
   );


### PR DESCRIPTION
## Summary
- replace uid() with auth.uid() in supplier and invoice_line policies

## Testing
- `supabase db reset` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bad7096c8321a30307ea4733b1ff