### PR TITLE
Avoid duplicate supplier policies in migration

### DIFF
--- a/supabase/migrations/20250823091659_sparkling_grove.sql
+++ b/supabase/migrations/20250823091659_sparkling_grove.sql
@@ -45,6 +45,7 @@ CREATE INDEX IF NOT EXISTS supplier_org_name_idx ON public.supplier (organizatio
 ALTER TABLE public.supplier ENABLE ROW LEVEL SECURITY;
 
 -- Create RLS policies for supplier table
+DROP POLICY IF EXISTS "Users can manage suppliers in their organization" ON public.supplier;
 CREATE POLICY "Users can manage suppliers in their organization"
   ON public.supplier
   FOR ALL
@@ -60,6 +61,7 @@ CREATE POLICY "Users can manage suppliers in their organization"
     WHERE profiles.user_id = auth.uid()
   ));
 
+DROP POLICY IF EXISTS "Users can read suppliers in their organization" ON public.supplier;
 CREATE POLICY "Users can read suppliers in their organization"
   ON public.supplier
   FOR SELECT


### PR DESCRIPTION
## Summary
- guard supplier policy creation with `DROP POLICY IF EXISTS`

## Testing
- `npx supabase db reset` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bc9b90cc8321951470dc776f0af9