### PR TITLE
chore: make policies idempotent

### DIFF
--- a/supabase/migrations/20250429145339_velvet_garden.sql
+++ b/supabase/migrations/20250429145339_velvet_garden.sql
@@ -29,12 +29,14 @@ CREATE TABLE IF NOT EXISTS profiles (
 
 ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire leur propre profil" ON profiles;
 CREATE POLICY "Les utilisateurs peuvent lire leur propre profil"
   ON profiles
   FOR SELECT
   TO authenticated
   USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "Les utilisateurs peuvent modifier leur propre profil" ON profiles;
 CREATE POLICY "Les utilisateurs peuvent modifier leur propre profil"
   ON profiles
   FOR UPDATE

--- a/supabase/migrations/20250430063631_twilight_spark.sql
+++ b/supabase/migrations/20250430063631_twilight_spark.sql
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS restaurant (
 ALTER TABLE restaurant ENABLE ROW LEVEL SECURITY;
 
 -- Les utilisateurs authentifiés peuvent lire tous les restaurants
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire tous les restaurants" ON restaurant;
 CREATE POLICY "Les utilisateurs peuvent lire tous les restaurants"
   ON restaurant
   FOR SELECT
@@ -35,6 +36,7 @@ CREATE POLICY "Les utilisateurs peuvent lire tous les restaurants"
   USING (true);
 
 -- Les utilisateurs peuvent uniquement modifier leurs propres restaurants
+DROP POLICY IF EXISTS "Les utilisateurs peuvent modifier leurs propres restaurants" ON restaurant;
 CREATE POLICY "Les utilisateurs peuvent modifier leurs propres restaurants"
   ON restaurant
   FOR ALL

--- a/supabase/migrations/20250430071726_twilight_beacon.sql
+++ b/supabase/migrations/20250430071726_twilight_beacon.sql
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS ingredient (
 ALTER TABLE ingredient ENABLE ROW LEVEL SECURITY;
 
 -- Politique de lecture
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire les ingrédients de leurs restaurants" ON ingredient;
 CREATE POLICY "Les utilisateurs peuvent lire les ingrédients de leurs restaurants"
   ON ingredient
   FOR SELECT
@@ -46,6 +47,7 @@ CREATE POLICY "Les utilisateurs peuvent lire les ingrédients de leurs restauran
   );
 
 -- Politique d'écriture
+DROP POLICY IF EXISTS "Les propriétaires peuvent gérer leurs ingrédients" ON ingredient;
 CREATE POLICY "Les propriétaires peuvent gérer leurs ingrédients"
   ON ingredient
   FOR ALL

--- a/supabase/migrations/20250430075511_dark_fire.sql
+++ b/supabase/migrations/20250430075511_dark_fire.sql
@@ -40,6 +40,7 @@ ALTER TABLE ingredient DROP COLUMN restaurant_id;
 ALTER TABLE ingredient ADD COLUMN organization_id uuid NOT NULL REFERENCES organization(id) ON DELETE CASCADE;
 
 -- Politiques RLS pour organization
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire leur propre organisation" ON organization;
 CREATE POLICY "Les utilisateurs peuvent lire leur propre organisation"
   ON organization
   FOR SELECT
@@ -52,6 +53,7 @@ CREATE POLICY "Les utilisateurs peuvent lire leur propre organisation"
     )
   );
 
+DROP POLICY IF EXISTS "Les utilisateurs peuvent gérer leur propre organisation" ON organization;
 CREATE POLICY "Les utilisateurs peuvent gérer leur propre organisation"
   ON organization
   FOR ALL
@@ -72,6 +74,7 @@ CREATE POLICY "Les utilisateurs peuvent gérer leur propre organisation"
   );
 
 -- Nouvelles politiques RLS pour ingredient
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire les ingrédients de leur organisation" ON ingredient;
 CREATE POLICY "Les utilisateurs peuvent lire les ingrédients de leur organisation"
   ON ingredient
   FOR SELECT
@@ -84,6 +87,7 @@ CREATE POLICY "Les utilisateurs peuvent lire les ingrédients de leur organisati
     )
   );
 
+DROP POLICY IF EXISTS "Les utilisateurs peuvent gérer les ingrédients de leur organisation" ON ingredient;
 CREATE POLICY "Les utilisateurs peuvent gérer les ingrédients de leur organisation"
   ON ingredient
   FOR ALL

--- a/supabase/migrations/20250430080129_falling_river.sql
+++ b/supabase/migrations/20250430080129_falling_river.sql
@@ -22,6 +22,7 @@ ADD COLUMN organization_id uuid NOT NULL
 REFERENCES organization(id) ON DELETE CASCADE;
 
 -- Nouvelle politique : lecture des restaurants de l'organisation
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire les restaurants de leur organisation" ON restaurant;
 CREATE POLICY "Les utilisateurs peuvent lire les restaurants de leur organisation"
   ON restaurant
   FOR SELECT
@@ -35,6 +36,7 @@ CREATE POLICY "Les utilisateurs peuvent lire les restaurants de leur organisatio
   );
 
 -- Nouvelle politique : gestion des restaurants de l'organisation
+DROP POLICY IF EXISTS "Les utilisateurs peuvent gérer les restaurants de leur organisation" ON restaurant;
 CREATE POLICY "Les utilisateurs peuvent gérer les restaurants de leur organisation"
   ON restaurant
   FOR ALL

--- a/supabase/migrations/20250430090544_steep_snow.sql
+++ b/supabase/migrations/20250430090544_steep_snow.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS product (
 ALTER TABLE product ENABLE ROW LEVEL SECURITY;
 
 -- Politique de lecture
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire les produits de leur organisation" ON product;
 CREATE POLICY "Les utilisateurs peuvent lire les produits de leur organisation"
   ON product
   FOR SELECT
@@ -50,6 +51,7 @@ CREATE POLICY "Les utilisateurs peuvent lire les produits de leur organisation"
   );
 
 -- Politique d'écriture
+DROP POLICY IF EXISTS "Les utilisateurs peuvent gérer les produits de leur organisation" ON product;
 CREATE POLICY "Les utilisateurs peuvent gérer les produits de leur organisation"
   ON product
   FOR ALL

--- a/supabase/migrations/20250430130401_raspy_glitter.sql
+++ b/supabase/migrations/20250430130401_raspy_glitter.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS recipes (
 ALTER TABLE recipes ENABLE ROW LEVEL SECURITY;
 
 -- Politiques pour recipes
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire les recettes de leur organisation" ON recipes;
 CREATE POLICY "Les utilisateurs peuvent lire les recettes de leur organisation"
   ON recipes
   FOR SELECT
@@ -56,6 +57,7 @@ CREATE POLICY "Les utilisateurs peuvent lire les recettes de leur organisation"
     )
   );
 
+DROP POLICY IF EXISTS "Les utilisateurs peuvent gérer les recettes de leur organisation" ON recipes;
 CREATE POLICY "Les utilisateurs peuvent gérer les recettes de leur organisation"
   ON recipes
   FOR ALL
@@ -96,6 +98,7 @@ CREATE TABLE IF NOT EXISTS recipe_ingredients (
 ALTER TABLE recipe_ingredients ENABLE ROW LEVEL SECURITY;
 
 -- Politiques pour recipe_ingredients
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire les ingrédients des recettes de leur organisation" ON recipe_ingredients;
 CREATE POLICY "Les utilisateurs peuvent lire les ingrédients des recettes de leur organisation"
   ON recipe_ingredients
   FOR SELECT
@@ -116,6 +119,7 @@ CREATE POLICY "Les utilisateurs peuvent lire les ingrédients des recettes de le
     )
   );
 
+DROP POLICY IF EXISTS "Les utilisateurs peuvent gérer les ingrédients des recettes de leur organisation" ON recipe_ingredients;
 CREATE POLICY "Les utilisateurs peuvent gérer les ingrédients des recettes de leur organisation"
   ON recipe_ingredients
   FOR ALL

--- a/supabase/migrations/20250501080310_black_river.sql
+++ b/supabase/migrations/20250501080310_black_river.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS invoice (
 ALTER TABLE invoice ENABLE ROW LEVEL SECURITY;
 
 -- Politique de lecture
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire les factures de leur organisation" ON invoice;
 CREATE POLICY "Les utilisateurs peuvent lire les factures de leur organisation"
   ON invoice
   FOR SELECT
@@ -53,6 +54,7 @@ CREATE POLICY "Les utilisateurs peuvent lire les factures de leur organisation"
   );
 
 -- Politique d'écriture
+DROP POLICY IF EXISTS "Les utilisateurs peuvent gérer les factures de leur organisation" ON invoice;
 CREATE POLICY "Les utilisateurs peuvent gérer les factures de leur organisation"
   ON invoice
   FOR ALL
@@ -73,6 +75,7 @@ CREATE POLICY "Les utilisateurs peuvent gérer les factures de leur organisation
   );
 
 -- Politiques de stockage pour le bucket invoices
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire leurs factures" ON storage.objects;
 CREATE POLICY "Les utilisateurs peuvent lire leurs factures"
   ON storage.objects
   FOR SELECT
@@ -86,6 +89,7 @@ CREATE POLICY "Les utilisateurs peuvent lire leurs factures"
     )
   );
 
+DROP POLICY IF EXISTS "Les utilisateurs peuvent uploader leurs factures" ON storage.objects;
 CREATE POLICY "Les utilisateurs peuvent uploader leurs factures"
   ON storage.objects
   FOR INSERT
@@ -99,6 +103,7 @@ CREATE POLICY "Les utilisateurs peuvent uploader leurs factures"
     )
   );
 
+DROP POLICY IF EXISTS "Les utilisateurs peuvent supprimer leurs factures" ON storage.objects;
 CREATE POLICY "Les utilisateurs peuvent supprimer leurs factures"
   ON storage.objects
   FOR DELETE

--- a/supabase/migrations/20250502084953_amber_wave.sql
+++ b/supabase/migrations/20250502084953_amber_wave.sql
@@ -28,6 +28,7 @@ CREATE INDEX ingredient_category_organization_id_idx ON ingredient_category(orga
 
 ALTER TABLE ingredient_category ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire les catégories globales et celles de leur organisation" ON ingredient_category;
 CREATE POLICY "Les utilisateurs peuvent lire les catégories globales et celles de leur organisation"
   ON ingredient_category
   FOR SELECT
@@ -41,6 +42,7 @@ CREATE POLICY "Les utilisateurs peuvent lire les catégories globales et celles 
     )
   );
 
+DROP POLICY IF EXISTS "Les utilisateurs peuvent gérer les catégories de leur organisation" ON ingredient_category;
 CREATE POLICY "Les utilisateurs peuvent gérer les catégories de leur organisation"
   ON ingredient_category
   FOR ALL

--- a/supabase/migrations/20250519084904_shiny_voice.sql
+++ b/supabase/migrations/20250519084904_shiny_voice.sql
@@ -72,6 +72,7 @@ ALTER TABLE organization_modules ENABLE ROW LEVEL SECURITY;
 ALTER TABLE subscription_logs ENABLE ROW LEVEL SECURITY;
 
 -- Politiques RLS pour organization_subscription
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire leur abonnement" ON organization_subscription;
 CREATE POLICY "Les utilisateurs peuvent lire leur abonnement"
   ON organization_subscription
   FOR SELECT
@@ -85,6 +86,7 @@ CREATE POLICY "Les utilisateurs peuvent lire leur abonnement"
   );
 
 -- Politiques RLS pour subscription_modules
+DROP POLICY IF EXISTS "Tout le monde peut lire les modules actifs" ON subscription_modules;
 CREATE POLICY "Tout le monde peut lire les modules actifs"
   ON subscription_modules
   FOR SELECT
@@ -92,6 +94,7 @@ CREATE POLICY "Tout le monde peut lire les modules actifs"
   USING (is_active = true);
 
 -- Politiques RLS pour organization_modules
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire leurs modules" ON organization_modules;
 CREATE POLICY "Les utilisateurs peuvent lire leurs modules"
   ON organization_modules
   FOR SELECT
@@ -105,6 +108,7 @@ CREATE POLICY "Les utilisateurs peuvent lire leurs modules"
   );
 
 -- Politiques RLS pour subscription_logs
+DROP POLICY IF EXISTS "Les utilisateurs peuvent lire leurs logs d'abonnement" ON subscription_logs;
 CREATE POLICY "Les utilisateurs peuvent lire leurs logs d'abonnement"
   ON subscription_logs
   FOR SELECT

--- a/supabase/migrations/20250522090723_tight_swamp.sql
+++ b/supabase/migrations/20250522090723_tight_swamp.sql
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS stripe_customers (
 
 ALTER TABLE stripe_customers ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can view their own customer data" ON stripe_customers;
 CREATE POLICY "Users can view their own customer data"
     ON stripe_customers
     FOR SELECT
@@ -80,6 +81,7 @@ CREATE TABLE IF NOT EXISTS stripe_subscriptions (
 
 ALTER TABLE stripe_subscriptions ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can view their own subscription data" ON stripe_subscriptions;
 CREATE POLICY "Users can view their own subscription data"
     ON stripe_subscriptions
     FOR SELECT
@@ -116,6 +118,7 @@ CREATE TABLE IF NOT EXISTS stripe_orders (
 
 ALTER TABLE stripe_orders ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can view their own order data" ON stripe_orders;
 CREATE POLICY "Users can view their own order data"
     ON stripe_orders
     FOR SELECT

--- a/supabase/migrations/20250522111305_proud_summit.sql
+++ b/supabase/migrations/20250522111305_proud_summit.sql
@@ -53,6 +53,7 @@ AND s.deleted_at IS NULL;
 -- Mise à jour des politiques RLS
 DROP POLICY IF EXISTS "Users can view their own subscription data" ON stripe_subscriptions;
 
+DROP POLICY IF EXISTS "Users can view their organization subscription data" ON stripe_subscriptions;
 CREATE POLICY "Users can view their organization subscription data"
     ON stripe_subscriptions
     FOR SELECT

--- a/supabase/migrations/20250823091233_autumn_grove.sql
+++ b/supabase/migrations/20250823091233_autumn_grove.sql
@@ -45,6 +45,7 @@ CREATE INDEX IF NOT EXISTS supplier_org_name_idx ON supplier (organization_id, n
 ALTER TABLE supplier ENABLE ROW LEVEL SECURITY;
 
 -- Create policies for supplier table
+DROP POLICY IF EXISTS "Users can manage suppliers in their organization" ON supplier;
 CREATE POLICY "Users can manage suppliers in their organization"
   ON supplier
   FOR ALL
@@ -60,6 +61,7 @@ CREATE POLICY "Users can manage suppliers in their organization"
     WHERE profiles.user_id = auth.uid()
   ));
 
+DROP POLICY IF EXISTS "Users can read suppliers in their organization" ON supplier;
 CREATE POLICY "Users can read suppliers in their organization"
   ON supplier
   FOR SELECT

--- a/supabase/migrations/20250823091659_sparkling_grove.sql
+++ b/supabase/migrations/20250823091659_sparkling_grove.sql
@@ -45,6 +45,7 @@ CREATE INDEX IF NOT EXISTS supplier_org_name_idx ON public.supplier (organizatio
 ALTER TABLE public.supplier ENABLE ROW LEVEL SECURITY;
 
 -- Create RLS policies for supplier table
+DROP POLICY IF EXISTS "Users can manage suppliers in their organization" ON public.supplier;
 CREATE POLICY "Users can manage suppliers in their organization"
   ON public.supplier
   FOR ALL
@@ -60,6 +61,7 @@ CREATE POLICY "Users can manage suppliers in their organization"
     WHERE profiles.user_id = auth.uid()
   ));
 
+DROP POLICY IF EXISTS "Users can read suppliers in their organization" ON public.supplier;
 CREATE POLICY "Users can read suppliers in their organization"
   ON public.supplier
   FOR SELECT

--- a/supabase/migrations/20250823125133_damp_desert.sql
+++ b/supabase/migrations/20250823125133_damp_desert.sql
@@ -51,6 +51,7 @@ CREATE INDEX IF NOT EXISTS invoice_line_ingredient_match_id_idx ON public.invoic
 
 ALTER TABLE public.invoice_line ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can read invoice lines of their organization" ON public.invoice_line;
 CREATE POLICY "Users can read invoice lines of their organization"
   ON public.invoice_line
   FOR SELECT


### PR DESCRIPTION
## Summary
- ensure all `CREATE POLICY` statements drop any existing policy first
- keep existing policies intact for rerunnable migrations

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `supabase --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bc9d70908321bf4e5630d3266ec2