### PR TITLE
chore: guard invoice date index creation

### DIFF
--- a/supabase/migrations/20250823091233_autumn_grove.sql
+++ b/supabase/migrations/20250823091233_autumn_grove.sql
@@ -94,5 +94,13 @@ BEGIN
   END IF;
 END $$;
 
--- Create useful index on invoice
-CREATE INDEX IF NOT EXISTS invoice_org_date_idx ON invoice (organization_id, date);
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'invoice' AND column_name = 'date'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS invoice_org_date_idx
+      ON invoice (organization_id, date);
+  END IF;
+END $$;

--- a/supabase/migrations/20250823091659_sparkling_grove.sql
+++ b/supabase/migrations/20250823091659_sparkling_grove.sql
@@ -92,5 +92,13 @@ BEGIN
   END IF;
 END $$;
 
--- Create index on invoice for organization and date
-CREATE INDEX IF NOT EXISTS invoice_org_date_idx ON public.invoice (organization_id, date);
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'invoice' AND column_name = 'date'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS invoice_org_date_idx
+      ON public.invoice (organization_id, date);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- wrap invoice date index creation in a conditional block to avoid missing column errors

## Testing
- `npx supabase db reset` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bef603f88321a68df088a706faa2