### PR TITLE
fix invoice_line foreign key

### DIFF
--- a/supabase/migrations/20250823125133_damp_desert.sql
+++ b/supabase/migrations/20250823125133_damp_desert.sql
@@ -1,3 +1,4 @@
+-- Corrects foreign key reference: ingredient_match_id now points to public.ingredient.
 /*
   # Create invoice_line table
 
@@ -15,7 +16,7 @@
       - `vat_rate` (numeric, >= 0)
       - `vat_amount_cents` (integer, >= 0)
       - `category_hint` (text, optional)
-      - `ingredient_match_id` (uuid, foreign key to ingredient_match)
+      - `ingredient_match_id` (uuid, foreign key to ingredient)
       - `confidence` (numeric, 0-1)
       - `created_at` (timestamptz)
 
@@ -41,7 +42,7 @@ CREATE TABLE IF NOT EXISTS public.invoice_line (
   vat_rate numeric NOT NULL CHECK (vat_rate >= 0),
   vat_amount_cents integer NOT NULL CHECK (vat_amount_cents >= 0),
   category_hint text,
-  ingredient_match_id uuid REFERENCES public.ingredient_match(id),
+  ingredient_match_id uuid REFERENCES public.ingredient(id),
   confidence numeric NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
   created_at timestamptz NOT NULL DEFAULT now()
 );

--- a/supabase/migrations/20251001000000_fix_invoice_line_fk.sql
+++ b/supabase/migrations/20251001000000_fix_invoice_line_fk.sql
@@ -1,0 +1,8 @@
+-- Supprime la contrainte erronée si elle existe
+ALTER TABLE public.invoice_line
+  DROP CONSTRAINT IF EXISTS invoice_line_ingredient_match_id_fkey;
+
+-- Ajoute la contrainte correcte vers public.ingredient
+ALTER TABLE public.invoice_line
+  ADD CONSTRAINT invoice_line_ingredient_id_fkey
+  FOREIGN KEY (ingredient_match_id) REFERENCES public.ingredient(id);


### PR DESCRIPTION
## Summary
- correct invoice_line.ingredient_match_id to reference ingredient
- add follow-up migration to drop wrong FK constraint and add correct one

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npx supabase db reset` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*
- `psql -c '\d public.invoice_line'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c47d5bf88321acee9ef9a3415c8d