### PR TITLE
fix: make invoice_line migration idempotent

### DIFF
--- a/supabase/migrations/20250823135705_still_torch.sql
+++ b/supabase/migrations/20250823135705_still_torch.sql
@@ -16,12 +16,14 @@
 
 -- Fix unit_base_qty column type and constraints
 ALTER TABLE public.invoice_line
+  DROP CONSTRAINT IF EXISTS invoice_line_unit_base_qty_check,
   ALTER COLUMN unit_base_qty TYPE int USING CEIL(unit_base_qty),
   ALTER COLUMN unit_base_qty SET NOT NULL,
   ADD CONSTRAINT invoice_line_unit_base_qty_check CHECK (unit_base_qty > 0);
 
 -- Fix confidence column to allow NULL values
 ALTER TABLE public.invoice_line
+  DROP CONSTRAINT IF EXISTS invoice_line_confidence_check,
   ALTER COLUMN confidence DROP NOT NULL,
   ADD CONSTRAINT invoice_line_confidence_check
     CHECK (confidence BETWEEN 0 AND 1 OR confidence IS NULL);


### PR DESCRIPTION
## Summary
- drop existing invoice_line constraints before re-adding to avoid duplicate errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68a9c6535d408321a24b84aff1c290ce