### PR TITLE
Aligner le bouton "Ajouter une facture" à droite

### DIFF
--- a/src/pages/invoices/InvoiceListPage.tsx
+++ b/src/pages/invoices/InvoiceListPage.tsx
@@ -148,14 +148,16 @@ export default function InvoiceListPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-8">Mes factures</h1>
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">Mes factures</h1>
 
-      <Button
-        icon={<Plus className="h-4 w-4" />}
-        onClick={() => setShowCreate(true)}
-      >
-        Ajouter une facture
-      </Button>
+        <Button
+          icon={<Plus className="h-4 w-4" />}
+          onClick={() => setShowCreate(true)}
+        >
+          Ajouter une facture
+        </Button>
+      </div>
 
       {invoices.length === 0 ? (
         <div className="text-center text-gray-500 mt-8">


### PR DESCRIPTION
## Summary
- Positionne le bouton **Ajouter une facture** à droite du titre pour harmoniser la page avec celle des recettes

## Testing
- `npm test` *(échoue : Missing script "test")*
- `npm run lint` *(échoue : ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9df13a9548321b142d98af9b1f2d1