### PR TITLE
Include currency field when retrieving invoice

### DIFF
--- a/src/services/invoice.ts
+++ b/src/services/invoice.ts
@@ -11,6 +11,7 @@ export async function getInvoiceById(id: string): Promise<InvoiceHeaderWithRelat
       invoice_number,
       invoice_date,
       status,
+      currency,
       subtotal_excl_cents,
       total_vat_cents,
       total_incl_cents,
@@ -28,6 +29,7 @@ export async function getInvoiceById(id: string): Promise<InvoiceHeaderWithRelat
 
   const rawHeader = {
     ...data,
+    currency: data.currency,
     supplier: Array.isArray(data.supplier) ? data.supplier[0] : data.supplier
   };
 


### PR DESCRIPTION
## Summary
- query invoice currency along with totals
- propagate currency into invoice header before validation

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run test:backend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec82e6268832195b40af745c9f567